### PR TITLE
🐛 Fix URL hash being removed from "Link Me"

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -102,7 +102,7 @@ app.on('activate', () => {
 app.on('web-contents-created', (e, contents) => {
   contents.on('will-navigate', (event, url) => {
     event.preventDefault();
-    shell.openExternal(`https://link-me.now.sh/?url=${url}`);
+    shell.openExternal(`https://link-me.now.sh/?url=${encodeURIComponent(url)}`);
   });
   contents.on('new-window', async (event, url) => {
     event.preventDefault();


### PR DESCRIPTION
Now encoding the `url` parameter value to preserve the hash of URLs.
Link Me already decodes the `url` parameter value, see [app.js#L8](https://github.com/CodingGarden/link-me/blob/4418ddb0c98eab19b1f2e84ff9719f9965c1641a/app.js#L8)

(Even though this is a small change, I've tested the code to make sure it works!)

---

By the way, should we update the `.now.sh` part of the Link Me URL to `.vercel.app` to avoid redirections?